### PR TITLE
Development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-/.settings
-/.buildpath
-/.project
+/composer.lock
+/vendor/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,64 @@
+PHP52to52
+===============================================================================
+PHP52to53 is a collection of sniffs for [PHP_CodeSniffer](http://pear.php.net/PHP_CodeSniffer) that check an PHP 5.2 application for PHP 5.3 compatibility.
+
+Features
+--------
+
+* Check for removed, deprecated or changed function, methods, constants etc. including stuff from removed or changed extensions
+* Scan for usage of added, changed or removed parameters
+* Search for removed ini-directives
+* ..
+
+Requirements
+------------
+
+* [PHP_CodeSniffer 1.3.6+](http://pear.php.net/PHP_CodeSniffer)
+
+Installation
+------------
+
+* **Composer**
+
+        Add `foobugs/php52to53` to the `require-dev` section of your composer.json and run `composer install`.
+        CodeSniffer can now be accessed from `vendor/bin/phpcs`.
+
+For the next two options make sure you’ve PHP_CodeSniffer installed. After that you can either put this standard into the PHP_CodeSniffer Standards directory located in your PEAR directory: (`pear/PHP/CodeSniffer/Standards`) or place the standard somewhere else and use it as standalone standard.
+
+* **Download**
+	
+	Download the [zip master](https://github.com/foobugs/PHP52to53/zipball/master) from github and extract it in the PHP_CodeSniffer Standards directory.
+
+* **Git-Clone-Install**
+
+	This script will go to your PHP_CodeSniffer Standards directory and place a clone of PHP52to53 Standard inside of it:
+
+        cd `pear config-get php_dir`/PHP/CodeSniffer/Standards
+        git clone git://github.com/foobugs/PHP52to53.git
+
+Usage
+-----
+
+### Installed standard
+
+If you have this standard copied or cloned into the PHPCodeSniffer Standards directory the standard should be listed when calling:
+
+	phpcs -i
+
+If `PHP52to53` is listed there you’re ready to use this standard on any directory:
+
+	phpcs --standard=PHP52to53 <source-path>
+
+### External standard
+	
+If you did not put the Standard into PHP_CodeSniffers Standard directory you can specify the external location of the standard. Note that the path to the standard must be a full qualified path:
+
+	phpcs -standard=/Users/frank/Downloads/PHP52to53/Standards/PHP52to53 <source-path>
+
+You can find more options and arguments (f.i. ignoring files, extensions, memory limit) in the official [PHP_CodeSniffer Manual](http://pear.php.net/manual/en/package.php.php-codesniffer.php).
+
+
+Participate!
+------------
+You can participate in this project by forking the [Repository](https://github.com/foobugs/PHP52to53) and push changes back to the project. Feel free to post issues or whishes in the [issue section](https://github.com/foobugs/PHP52to53/issues).
+

--- a/composer.json
+++ b/composer.json
@@ -27,13 +27,12 @@
         "source": "https://github.com/foobugs/PHP52to53"
     },
     "require": {
-        "php": ">=5.2",
         "goatherd/phpcs_installer": "*"
     },
     "autoload": {
         "psr-0": { "PHP52to53_": "./PHP52to53" }
     },
     "extra": {
-        "phpcs-name": "PHP52to53"
+        "phpcs-standard": "PHP52to53"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,39 @@
+{
+    "name": "goatherd/php52to53",
+    "description": "PHP52to53 is a collection of sniffs for PHP_CodeSniffer that check an PHP 5.2 application for PHP 5.3 compatibility.",
+    "type": "phpcs-standard",
+    "keywords": [
+        "phpcs",
+        "standards",
+        "php5.2",
+        "php5.3",
+        "compatibility"
+    ],
+    "homepage": "https://github.com/foobugs/PHP52to53",
+    "license": "BSD-3-clause",
+    "authors": [
+        {
+            "name": "Marcel Eichner"
+        },
+        {
+            "name": "Maik Penz"
+        },
+        {
+            "name": "René Oelke"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/foobugs/PHP52to53/issues",
+        "source": "https://github.com/foobugs/PHP52to53"
+    },
+    "require": {
+        "php": ">=5.2",
+        "goatherd/phpcs_installer": "*"
+    },
+    "autoload": {
+        "psr-0": { "PHP52to53\\": "./PHP52to53" }
+    },
+    "extra": {
+        "phpcs-name": "PHP52to53"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "goatherd/phpcs_installer": "*"
     },
     "autoload": {
-        "psr-0": { "PHP52to53\\": "./PHP52to53" }
+        "psr-0": { "PHP52to53_": "./PHP52to53" }
     },
     "extra": {
         "phpcs-name": "PHP52to53"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "compatibility"
     ],
     "homepage": "https://github.com/foobugs/PHP52to53",
-    "license": "BSD-3-clause",
+    "license": "BSD-3-Clause",
     "authors": [
         {
             "name": "Marcel Eichner"


### PR DESCRIPTION
Added readme, composer.json and fixed .gitignore.
Should rename vendor and register with packagist for release.

Advantages of this patch are
- it is documented
- it is trivial to install with a single line to `require-dev` of any composer.json

Test with

``` json
{
    "repositories": [
        {
            "type": "vcs",
            "url": "https://github.com/goatherd/PHP52to53"
        }
    ],
    "require": {
        "goatherd/php52to53": "dev-master"
    }
}
```

And query `./vendor/bin/phpcs -i`.

The _repository_ part is needed only since it is not registered with packagist yet.
