### PR TITLE
Typo fixed in php versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ Installation
 
 ### Composer
 
-You cann add the standard to your vendors directory by adding the dependency to your projects `composer.json`:
+You can add the standard to your vendors directory by adding the dependency to your projects `composer.json`:
 
 	"require": {
-    	"foobugs-standards": "php53to54",
+    	"foobugs-standards/php52to53": "dev-master",
 	}
 
 After an update with `composer update`, you’re able to include the standard via the full path using the `--standard` parameter:
 
-	vendor/bin/phpcs --standard="`pwd`/vendor/foobugs-standards/php53to54" <targetDir>
+	vendor/bin/phpcs --standard="`pwd`/vendor/foobugs-standards/php52to53" <targetDir>
 
 ### Download 
 

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,6 @@
         "goatherd/phpcs_installer": "*"
     },
     "extra": {
-        "phpcs-standard": "Php53to54"
+        "phpcs-standard": "Php52to53"
     }
 }


### PR DESCRIPTION
Small typo fix which fixes clash between 52-53 and 53-54 versions.
